### PR TITLE
Remove usage of `res._headers` private field (Fixes Issue #8)

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -30,7 +30,7 @@ var Utils = {
     if (socket._httpMessage) {
       result.method = socket._httpMessage.method;
       result.path = socket._httpMessage.path;
-      result.headers = socket._httpMessage._headers;
+      result.headers = "function" === typeof socket._httpMessage.getHeaders ? socket._httpMessage.getHeaders() : socket._httpMessage._headers;
     }
 
     result.listeners = Utils.extractListeners(socket, 'connect');


### PR DESCRIPTION
OutgoingMessage.prototype._headers is deprecated

https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_prototype_headers_outgoingmessage_prototype_headernames

Fixes: #8